### PR TITLE
Incorrect variable declaration location

### DIFF
--- a/main.py
+++ b/main.py
@@ -563,8 +563,8 @@ class PPG(QWidget):
                     value.append(serial_val)
 
                     if self.ui.data_record_flag:
+                        elapsed_time = (datetime.now() - self.ui.record_start_time).total_seconds()*1000
                         if self.ui.timed_acquisition:
-                            elapsed_time = (datetime.now() - self.ui.record_start_time).total_seconds()*1000
                             if (elapsed_time >= self.ui.curr_acquisition_time_ms):
                                 self.ui.data_record_flag = False
                                 mySrc.stop_signal.emit(True)


### PR DESCRIPTION
We are one of COMP0053 mini-project groups, during the use of this kit in our project, we found that the `elapsed_time` is declared in a wrong place, such that when the data is being recorded, the waveform chart stop updating and error message: `error in reading data ...` keep coming out through stdout. The data can be recorded correctly, but the freezing chart is pretty annoying as it prevent user to monitor the data collection phase for any potential anomaly.

We here to propose the fix and hopefully it would be helpful for any other user of this kit.